### PR TITLE
Use implementation instead of compile in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ allprojects {
 
 dependencies {
 
-  compile 'com.github.VRGsoftUA:Kotlin-Link-Parser:1.0.0'
+  implementation 'com.github.VRGsoftUA:Kotlin-Link-Parser:1.0.0'
 
 }
 ```


### PR DESCRIPTION
compile is deprecated.