### PR TITLE
Manage dependency versions in a single file.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,48 +1,48 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply from: '../dependencies.gradle'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+  compileSdkVersion versions.compileSdk
+  buildToolsVersion versions.buildTools
 
-    defaultConfig {
-        applicationId "net.vrgsoft.rxurlparser"
-        minSdkVersion 16
-        targetSdkVersion 25
-        versionCode 1
-        versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
+  defaultConfig {
+    applicationId "net.vrgsoft.rxurlparser"
+    minSdkVersion versions.minSdk
+    targetSdkVersion versions.compileSdk
+    versionCode versions.publishVersionCode
+    versionName versions.publishVersion
+    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+  }
 
-    dataBinding {
-        enabled = true
-    }
+  dataBinding {
+    enabled = true
+  }
 
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+  buildTypes {
+    release {
+      minifyEnabled false
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
+  }
 }
 
 kapt {
-    generateStubs = true
-}
-
-dependencies {
-
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    compile project(path: ':library')
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'com.github.bumptech.glide:glide:4.0.0-RC0'
-    kapt "com.android.databinding:compiler:2.3.2"
+  generateStubs = true
 }
 
 repositories {
-    google()
-    mavenCentral()
+  google()
+  jcenter()
+}
+
+dependencies {
+  implementation project(path: ':library')
+
+  implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:' + versions.kotlin
+  implementation 'com.android.support:appcompat-v7:' + versions.supportLib
+  implementation 'com.android.support.constraint:constraint-layout:' + versions.constraintLayout
+  implementation 'com.github.bumptech.glide:glide:' + versions.glide
+  kapt 'com.android.databinding:compiler:' + versions.dataBinding
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,24 @@
 buildscript {
-    ext.kotlin_version = '1.3.10'
-    repositories {
-        google()
-        jcenter()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+  apply from: './dependencies.gradle'
+
+  repositories {
+    google()
+    jcenter()
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:' + versions.gradlePlugin
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:' + versions.kotlin
+  }
 }
 
 allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 }
 
 task clean(type: Delete) {
-    delete rootProject.buildDir
+  delete rootProject.buildDir
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,19 @@
+ext.versions = [
+    minSdk            : 16,
+    compileSdk        : 28,
+    buildTools        : '28.0.3',
+    publishVersion    : '1.0.0',
+    publishVersionCode: 1,
+
+    gradlePlugin      : '3.2.1',
+
+    kotlin            : '1.3.10',
+    supportLib        : '28.0.0',
+    rxKotlin          : '2.0.3',
+    jsoup             : '1.10.2',
+
+    anko              : '0.10.1',
+    glide             : '4.7.1',
+    dataBinding       : '2.3.2',
+    constraintLayout  : '1.0.2'
+]

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,28 +1,33 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply from: '../dependencies.gradle'
+
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+  compileSdkVersion versions.compileSdk
+  buildToolsVersion versions.buildTools
 
-    defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
-        versionCode 1
-        versionName "1.0"
-    }
+  defaultConfig {
+    minSdkVersion versions.minSdk
+    targetSdkVersion versions.compileSdk
+    versionCode versions.publishVersionCode
+    versionName versions.publishVersion
+  }
 
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+  buildTypes {
+    release {
+      minifyEnabled false
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
+  }
+}
+
+repositories {
+  google()
+  jcenter()
 }
 
 dependencies {
-    ext.anko_version = '0.10.1'
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'io.reactivex.rxjava2:rxkotlin:2.0.3'
-    compile "org.jetbrains.anko:anko-commons:$anko_version"
-    compile 'org.jsoup:jsoup:1.10.2'
+  api 'io.reactivex.rxjava2:rxkotlin:' + versions.rxKotlin
+  implementation 'org.jetbrains.anko:anko-commons:' + versions.anko
+  implementation 'org.jsoup:jsoup:' + versions.jsoup
 }


### PR DESCRIPTION
* This way, you don't have to remember to update multiple spots. 
* Also upgraded the support library since the compileSdk is 28.
* Switched to the JDK Kotlin dependency (JRE no longer exists with latest 1.3.x versions).