### PR TITLE
#6 unused headerFields & remove logic to unshortUrl

### DIFF
--- a/app/src/main/java/net/vrgsoft/rxurlparser/MainActivity.kt
+++ b/app/src/main/java/net/vrgsoft/rxurlparser/MainActivity.kt
@@ -13,7 +13,8 @@ class MainActivity : AppCompatActivity() {
   private lateinit var mBinding: ActivityMainBinding
   private val crawler = LinkCrawler()
 
-  private var parseSubscription: Disposable? = null
+  private var githubSubscription: Disposable? = null
+  private var youtubeSubscription: Disposable? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -24,15 +25,22 @@ class MainActivity : AppCompatActivity() {
           .show()
     }
 
-    parseSubscription =
+    githubSubscription =
         crawler.parseUrl("https://github.com")
             .subscribe { t ->
-              mBinding.content = t.result
+              mBinding.contentGithub = t.result
+            }
+
+    youtubeSubscription =
+        crawler.parseUrl("https://youtu.be/X1RVYt2QKQE")
+            .subscribe { t ->
+              mBinding.contentYoutube = t.result
             }
   }
 
   override fun onPause() {
-    parseSubscription?.dispose()
+    githubSubscription?.dispose()
+    youtubeSubscription?.dispose()
     super.onPause()
   }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,11 @@
     <data>
 
         <variable
-            name="content"
+            name="content_github"
+            type="net.vrgsoft.library.ParseContent" />
+
+        <variable
+            name="content_youtube"
             type="net.vrgsoft.library.ParseContent" />
     </data>
 
@@ -16,45 +20,81 @@
         tools:context="net.vrgsoft.rxurlparser.MainActivity">
 
         <TextView
-            android:id="@+id/title"
+            android:id="@+id/github_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/small_margin"
             android:layout_marginRight="@dimen/small_margin"
             android:layout_marginTop="8dp"
-            android:text="@{content.title}"
+            android:text="@{content_github.title}"
             android:textAlignment="center"
+            android:textStyle="bold"
             app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="Title" />
 
         <TextView
-            android:id="@+id/description"
+            android:id="@+id/github_description"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/small_margin"
             android:layout_marginRight="@dimen/small_margin"
             android:layout_marginTop="@dimen/small_margin"
-            android:text="@{content.description}"
-            android:textAlignment="center"
+            android:text="@{content_github.description}"
             app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/title"
+            app:layout_constraintTop_toBottomOf="@+id/github_title"
             tools:text="Description" />
 
         <TextView
-            android:id="@+id/url"
+            android:id="@+id/github_url"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/small_margin"
+            android:layout_marginTop="@dimen/small_margin"
+            android:layout_marginRight="@dimen/small_margin"
+            android:text="@{content_github.finalUrl}"
+            android:textAlignment="center"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/github_description"
+            tools:text="www.vrgsoft.net" />
+
+        <TextView
+            android:id="@+id/youtube_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/small_margin"
+            android:layout_marginTop="16dp"
+            android:layout_marginRight="@dimen/small_margin"
+            android:text="@{content_youtube.title}"
+            android:textAlignment="center"
+            android:textStyle="bold"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/github_url"
+            tools:text="Title" />
+
+        <TextView
+            android:id="@+id/youtube_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/small_margin"
+            android:layout_marginTop="@dimen/small_margin"
+            android:layout_marginRight="@dimen/small_margin"
+            android:text="@{content_youtube.description}"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/youtube_title"
+            tools:text="Description" />
+
+        <TextView
+            android:id="@+id/youtube_url"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/small_margin"
             android:layout_marginRight="@dimen/small_margin"
             android:layout_marginTop="@dimen/small_margin"
-            android:text="@{content.finalUrl}"
+            android:text="@{content_youtube.finalUrl}"
             android:textAlignment="center"
             app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/description"
+            app:layout_constraintTop_toBottomOf="@+id/youtube_description"
             tools:text="www.vrgsoft.net" />
     </android.support.constraint.ConstraintLayout>
 </layout>


### PR DESCRIPTION
- remove logic to remove `unshortUrl` as Jsoup does it internally 
- use `content.url` for original URL & `content.finalUrl` for final URL after redirection
- update sample with an example for unshort URL with youtube URL

Issue: #6 